### PR TITLE
nspr 4.33

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* ./nspr/build/autoconf
+
+export HOST_CC=$CC_FOR_BUILD
 
 cd nspr
 
-./configure --prefix="${PREFIX}" --enable-64bit
+sed -ri 's#^(RELEASE_BINS =).*#\1#' pr/src/misc/Makefile.in
+sed -i 's#$(LIBRARY) ##'            config/rules.mk
+
+./configure --prefix="${PREFIX}" --enable-64bit --disable-debug --enable-optimize --with-pthreads --with-mozilla || (cat config.log; false)
 
 make -j $CPU_COUNT
 make install

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,2 @@
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.11.sdk
-macos_min_version:
-  - 10.11
-macos_machine:
-  - x86_64-apple-darwin13.4.0
-MACOSX_DEPLOYMENT_TARGET:
-  - 10.11
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - 10.13                  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - test -f ${PREFIX}/bin/nspr-config                  # [unix]
 
 about:
-  home: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
+  home: https://hg.mozilla.org/projects/nspr
   license: MPL-2.0
   license_file: nspr/LICENSE
   summary: A platform-neutral API for system level and libc-like functions.
@@ -42,8 +42,8 @@ about:
     thread synchronization, normal file and network I/O, interval timing and
     calendar time, basic memory management (malloc and free) and shared
     library linking.
-  doc_url: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
-  dev_url: https://developer.mozilla.org/en-US/docs/MDN
+  doc_url: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Reference/NSPR_functions
+  dev_url: https://hg.mozilla.org/projects/nspr
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,37 +1,39 @@
-{% set version = "4.22" %}
+{% set version = "4.33" %}
 
 package:
   name: nspr
   version: {{ version }}
 
 source:
-  fn: nspr-{{ version }}.tgz
   url: https://ftp.mozilla.org/pub/nspr/releases/v{{ version }}/src/nspr-{{ version }}.tar.gz
-  sha256: c9e4b6cc24856ec93202fe13704b38b38ba219f0f2aeac93090ce2b6c696d430
+  sha256: b23ee315be0e50c2fb1aa374d17f2d2d9146a835b1a79c1918ea15d075a693d7
 
 build:
   number: 0
   skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage('nspr', max_pin='x') }}
 
 requirements:
   build:
+    - gnuconfig  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make
     - autoconf
+    - sed
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libnspr4.a                   # [unix]
     - test -f ${PREFIX}/lib/libnspr4${SHLIB_EXT}         # [unix]
-    - test -f ${PREFIX}/lib/libplc4.a                    # [unix]
     - test -f ${PREFIX}/lib/libplc4${SHLIB_EXT}          # [unix]
-    - test -f ${PREFIX}/lib/libplds4.a                   # [unix]
     - test -f ${PREFIX}/lib/libplds4${SHLIB_EXT}         # [unix]
+    - test -d ${PREFIX}/include/nspr                     # [unix]
+    - test -f ${PREFIX}/bin/nspr-config                  # [unix]
 
 about:
   home: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
-  license: MPL 2
+  license: MPL-2.0
   license_file: nspr/LICENSE
   summary: A platform-neutral API for system level and libc-like functions.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ test:
 about:
   home: https://hg.mozilla.org/projects/nspr
   license: MPL-2.0
+  license_family: OTHER
   license_file: nspr/LICENSE
   summary: A platform-neutral API for system level and libc-like functions.
   description: |


### PR DESCRIPTION
`nss 3.74` requires `nspr`, see https://github.com/AnacondaRecipes/nss-feedstock/pull/1

License: https://hg.mozilla.org/projects/nspr/file/tip/LICENSE
Changelog: https://hg.mozilla.org/projects/nspr/log
Installation (not upstream): https://www.linuxfromscratch.org/blfs/view/svn/general/nspr.html

Actions:
1. Update build.sh for osx-arm64 support
2. Update cbc.yaml for osx
3. Update dependencies: add `- gnuconfig  # [unix]` for osx-arm64
4. Update test/commands
5. Fix home, dev, doc urls